### PR TITLE
callwaiterdaki parametre gönderme hatası çözüldü

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -36,7 +36,7 @@ $routes->set404Override();
 // We get a performance increase by specifying the default
 // route since we don't have to scan directories.
 $routes->get('/', 'Anasayfa::index');
-
+$routes->get('call/(:num)', 'Anasayfa::call/$1');
 $routes->get('/login', 'Login::index');
 $routes->post('/login/kontrol', 'Login::kontrol');
 
@@ -50,8 +50,7 @@ $routes->group('panel', static function ($routes) {
     $routes->get('categoryDelete/(:num)', 'Home::categoryDelete/$1');
     $routes->get('products_info/(:num)/(:num)', 'Home::productsInfo/$1/$2');
     $routes->get('productsDelete/(:num)', 'Home::productsDelete/$1');
-    $routes->get('productsEditView/(:num)', 'Home::productsEditView/$1');
-    $routes->get('call/(:num)', 'Anasayfa::call/$1');
+    $routes->get('productsEditView/(:num)', 'Home::productsEditView/$1');   
     $routes->get('callView', 'Home::call_view');
     $routes->get('callDelete/(:num)', 'Home::callDelete/$1');
     $routes->post('productEdit/(:num)', 'Home::productEdit/$1');

--- a/app/Views/menu.php
+++ b/app/Views/menu.php
@@ -61,11 +61,14 @@
                     Dogan Lokantası
                 </h2>
                 <br>
-                <?php $table_no = $_GET["id"]; ?>
+                <?php if ($_GET) : ?>
+                <?php $table_no = $_GET["id"]; ?>               
                 <a href="<?= base_url('call/' . $table_no) ?>"><button type="submit"
                         style="background-color:#FF5733; color:white;" type="button" class="btn btn"><b>GARSON
                             ÇAĞIR</b></button></a>
                 <br>
+                <?php endif; ?>
+                               
                 <?php if (session()->get('info')) : ?>
                 <div class="alert alert-info" style="text-align:center;" role="alert">
                     <?php echo session()->getFlashdata('info'); ?>


### PR DESCRIPTION
call waiter metoduna gelen parametre düznlendi route kısmı panelin altındaki groupda kaldığı için işlevini yitirmişti bir üste taşındı.Ayriyetten .../id gönderilmesede anasayfa çalışacak garson çağır butonu gözükmeyecek şekilde kodlandı